### PR TITLE
Lockmanager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.12
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	go.uber.org/goleak v1.0.0
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )

--- a/unison/lockmanager.go
+++ b/unison/lockmanager.go
@@ -1,0 +1,328 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unison
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/elastic/go-concert"
+	"github.com/elastic/go-concert/atomic"
+)
+
+type LockManager struct {
+	mu    sync.Mutex
+	table map[string]*lockEntry
+}
+
+type ManagedLock struct {
+	key     string
+	manager *LockManager
+	session *LockSession
+	entry   *lockEntry
+}
+
+type LockSession struct {
+	isLocked             atomic.Bool
+	done, unlocked, lost *sigChannel
+}
+
+type lockEntry struct {
+	session    *LockSession
+	muInternal sync.Mutex // internal mutex
+
+	// shared user mutex
+	Mutex
+
+	// book keeping, so we can remove the entry from the lock manager if there
+	// are not more references to this entry.
+	key string
+	ref concert.RefCount
+}
+
+type sigChannel struct {
+	once sync.Once
+	ch   chan struct{}
+}
+
+var managedLockFinalizer = (*ManagedLock).finalize
+
+func NewLockManager() *LockManager {
+	return &LockManager{table: map[string]*lockEntry{}}
+}
+
+func (m *LockManager) Access(key string) *ManagedLock {
+	return newManagedLock(m, key)
+}
+
+func (m *LockManager) ForceUnlock(key string) {
+	m.mu.Lock()
+	entry := m.findEntry(key)
+	m.mu.Unlock()
+
+	entry.muInternal.Lock()
+	session := entry.session
+	if session != nil {
+		entry.session = nil
+		if session.isLocked.Load() {
+			entry.Mutex.Unlock()
+		}
+
+	}
+	entry.muInternal.Unlock()
+
+	session.forceUnlock()
+	m.releaseEntry(entry)
+}
+
+func (m *LockManager) ForceUnlockAll() {
+	m.mu.Lock()
+	for _, entry := range m.table {
+		entry.muInternal.Lock()
+		session := entry.session
+		if session != nil && session.isLocked.Load() {
+			entry.session = nil
+			entry.Mutex.Unlock()
+		}
+		entry.muInternal.Unlock()
+
+		session.forceUnlock()
+	}
+	m.mu.Unlock()
+}
+
+func (m *LockManager) createEntry(key string) *lockEntry {
+	entry := &lockEntry{
+		Mutex: MakeMutex(),
+		key:   key,
+	}
+	m.table[key] = entry
+	return entry
+}
+
+func (m *LockManager) findEntry(key string) *lockEntry {
+	entry := m.table[key]
+	if entry != nil {
+		entry.ref.Retain()
+	}
+	return entry
+}
+
+func (m *LockManager) findOrCreate(key string, create bool) (entry *lockEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if entry = m.findEntry(key); entry == nil && create {
+		entry = m.createEntry(key)
+	}
+	return entry
+}
+
+func (m *LockManager) releaseEntry(entry *lockEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if entry.ref.Release() {
+		delete(m.table, entry.key)
+	}
+}
+
+func newManagedLock(mngr *LockManager, key string) *ManagedLock {
+	ml := &ManagedLock{key: key, manager: mngr}
+	return ml
+}
+
+func (ml *ManagedLock) finalize() {
+	defer ml.unlink()
+	if ml.session != nil {
+		ml.doUnlock()
+	}
+}
+
+// Key reports the key the lock will lock/unlock.
+func (ml *ManagedLock) Key() string {
+	return ml.key
+}
+
+// Lock the key. It blocks until the lock becomes
+// available.
+func (ml *ManagedLock) Lock() *LockSession {
+	checkNoActiveLockSession(ml.session)
+
+	ml.link(true)
+	ml.entry.Lock()
+	return ml.markLocked()
+}
+
+func (ml *ManagedLock) TryLock() (*LockSession, bool) {
+	checkNoActiveLockSession(ml.session)
+
+	ml.link(true)
+	if !ml.entry.TryLock() {
+		ml.unlink()
+		return nil, false
+	}
+
+	return ml.markLocked(), true
+}
+
+func (ml *ManagedLock) LockTimeout(duration time.Duration) (*LockSession, bool) {
+	checkNoActiveLockSession(ml.session)
+
+	ml.link(true)
+	if !ml.entry.LockTimeout(duration) {
+		ml.unlink()
+		return nil, false
+	}
+	return ml.markLocked(), ml.IsLocked()
+}
+
+func (ml *ManagedLock) LockContext(context doneContext) (*LockSession, error) {
+	checkNoActiveLockSession(ml.session)
+
+	ml.link(true)
+	err := ml.entry.LockContext(context)
+	if err != nil {
+		ml.unlink()
+		return nil, err
+	}
+
+	return ml.markLocked(), nil
+}
+
+// Unlock releases a resource.
+func (ml *ManagedLock) Unlock() {
+	checkActiveLockSession(ml.session)
+	ml.doUnlock()
+}
+
+func (ml *ManagedLock) doUnlock() {
+	session, entry := ml.session, ml.entry
+
+	// The lock can be forcefully and asynchronously unreleased by the
+	// LockManager. We can only unlock the entry, iff our mutex session is
+	// still locked and the entries lock session still matches our lock session.
+	// If none of these is the case, then the session was already closed.
+	entry.muInternal.Lock()
+	if session == entry.session {
+		entry.session = nil
+		if session.isLocked.Load() {
+			entry.Unlock()
+		}
+	}
+	entry.muInternal.Unlock()
+
+	// always signal unlock, independent of the current state of the registry.
+	// This will trigger the 'Unlocked' signal, indicating to session listeners that
+	// the routine holding the lock deliberately unlocked the ManagedLock.
+	// Note: a managed lock must always be explicitely unlocked, no matter of the
+	// session state.
+	session.unlock()
+
+	ml.unlink()
+	ml.markUnlocked()
+}
+
+// IsLocked checks if the resource currently holds the lock for the key
+func (ml *ManagedLock) IsLocked() bool {
+	return ml.session != nil && ml.session.isLocked.Load()
+}
+
+func (ml *ManagedLock) link(create bool) {
+	if ml.entry == nil {
+		ml.entry = ml.manager.findOrCreate(ml.key, create)
+	}
+}
+
+func (ml *ManagedLock) unlink() {
+	if ml.entry == nil {
+		return
+	}
+
+	entry := ml.entry
+	ml.entry = nil
+	ml.manager.releaseEntry(entry)
+}
+
+func (ml *ManagedLock) markLocked() *LockSession {
+	session := newLockSession()
+	ml.session = session
+
+	ml.entry.muInternal.Lock()
+	ml.entry.session = session
+	ml.entry.muInternal.Unlock()
+
+	// in case we miss an unlock operation (programmer error or panic that hash
+	// been caught) we set a finalizer to eventually free the resource.
+	// The Unlock operation will unsert the finalizer.
+	runtime.SetFinalizer(ml, managedLockFinalizer)
+	return session
+}
+
+func (ml *ManagedLock) markUnlocked() {
+	runtime.SetFinalizer(ml, nil)
+}
+
+func newLockSession() *LockSession {
+	return &LockSession{
+		isLocked: atomic.MakeBool(true),
+		done:     newSigChannel(),
+		unlocked: newSigChannel(),
+		lost:     newSigChannel(),
+	}
+}
+
+func (s *LockSession) Done() <-chan struct{}     { return s.done.Sig() }
+func (s *LockSession) Unlocked() <-chan struct{} { return s.unlocked.Sig() }
+func (s *LockSession) LockLost() <-chan struct{} { return s.lost.Sig() }
+
+func (s *LockSession) unlock()      { s.doUnlock(s.unlocked) }
+func (s *LockSession) forceUnlock() { s.doUnlock(s.lost) }
+func (s *LockSession) doUnlock(kind *sigChannel) {
+	s.isLocked.Store(false)
+	kind.Close()
+	s.done.Close()
+}
+
+func newSigChannel() *sigChannel {
+	return &sigChannel{ch: make(chan struct{})}
+}
+
+func (s *sigChannel) Sig() <-chan struct{} {
+	return s.ch
+}
+
+func (s *sigChannel) Close() {
+	s.once.Do(func() {
+		close(s.ch)
+	})
+}
+
+func checkNoActiveLockSession(s *LockSession) {
+	invariant(s == nil, "lock still has an active lock session, missing call to Unlock to finish the session")
+}
+
+func checkActiveLockSession(s *LockSession) {
+	invariant(s != nil, "no active lock session")
+}
+
+func invariant(b bool, message string) {
+	if !b {
+		panic(errors.New(message))
+	}
+}

--- a/unison/lockmanager_test.go
+++ b/unison/lockmanager_test.go
@@ -42,7 +42,7 @@ func TestLockManager(t *testing.T) {
 			require.Equal(t, 1, len(lm.table), "expected shared entry to be generated when locking")
 
 			lock.Unlock()
-			require.Equal(t, 0, len(lm.table), "expected sharede entry to be freed after unlock")
+			require.Equal(t, 0, len(lm.table), "expected shared entry to be freed after unlock")
 		})
 
 		t.Run("garbage collecting a ManagedLock frees shared entries in the LockManager", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestLockManager(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				runtime.GC()
 			}
-			require.Equal(t, 0, len(lm.table), "expected sharede entry to be freed after unlock")
+			require.Equal(t, 0, len(lm.table), "expected shared entry to be freed after unlock")
 		})
 	})
 

--- a/unison/lockmanager_test.go
+++ b/unison/lockmanager_test.go
@@ -1,0 +1,296 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unison
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockManager(t *testing.T) {
+	// test some internals, just to make sure the ManagedLock correctly
+	// frees/deletes resources not needed anymore
+	t.Run("internals", func(t *testing.T) {
+		t.Run("shared lock entries are allocated lazily", func(t *testing.T) {
+			lm := NewLockManager()
+			lock := lm.Access("key")
+
+			require.Equal(t, 0, len(lm.table), "expected to have no shared entry in the table")
+
+			lock.Lock()
+			require.Equal(t, 1, len(lm.table), "expected shared entry to be generated when locking")
+
+			lock.Unlock()
+			require.Equal(t, 0, len(lm.table), "expected sharede entry to be freed after unlock")
+		})
+
+		t.Run("garbage collecting a ManagedLock frees shared entries in the LockManager", func(t *testing.T) {
+			lm := NewLockManager()
+
+			func() {
+				lock := lm.Access("key")
+				lock.Lock()
+				require.Equal(t, 1, len(lm.table), "expected shared entry to be generated when locking")
+			}()
+
+			for i := 0; i < 10; i++ {
+				runtime.GC()
+			}
+			require.Equal(t, 0, len(lm.table), "expected sharede entry to be freed after unlock")
+		})
+	})
+
+	t.Run("panic if we attempt to lock the same instance twice", func(t *testing.T) {
+		lm := NewLockManager()
+		lock := lm.Access("key")
+		lock.Lock()
+		defer lock.Unlock()
+		expectPanic(t, func() { lock.Lock() })
+	})
+
+	t.Run("mutex can only be held by one lock instance", func(t *testing.T) {
+		lm := NewLockManager()
+		lock1, lock2 := lm.Access("key"), lm.Access("key")
+
+		_, locked := lock1.TryLock()
+		require.True(t, locked)
+
+		_, locked = lock2.TryLock()
+		require.False(t, locked)
+
+		lock1.Unlock()
+	})
+
+	t.Run("mutex is transmissible", func(t *testing.T) {
+		lm := NewLockManager()
+		lock := lm.Access("key")
+		lock.Lock()
+
+		// create second go-routine that will block unless it can acquire the lock
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lock := lm.Access("key")
+			lock.Lock()
+			lock.Unlock()
+		}()
+
+		// unlock and wait for helper go-routine to quit
+		lock.Unlock()
+		wg.Wait() // <- deadlock if the test failed
+	})
+
+	t.Run("garbage collector releases lock", func(t *testing.T) {
+		lm := NewLockManager()
+		lock := lm.Access("key")
+
+		finalizerCalled := false
+		oldFinalizer := managedLockFinalizer
+		managedLockFinalizer = func(l *ManagedLock) {
+			finalizerCalled = true
+			oldFinalizer(l)
+		}
+		defer func() { managedLockFinalizer = oldFinalizer }()
+
+		func() {
+			tmp := lm.Access("key")
+			tmp.Lock()
+		}()
+
+		for i := 0; i < 10; i++ {
+			runtime.GC()
+		}
+		_, locked := lock.TryLock()
+		require.True(t, locked)
+		lock.Unlock()
+
+		assert.True(t, finalizerCalled)
+	})
+
+	t.Run("lock with timeout", func(t *testing.T) {
+		t.Run("success if not taken", func(t *testing.T) {
+			lm := NewLockManager()
+			lock := lm.Access("key")
+			_, locked := lock.LockTimeout(10 * time.Millisecond)
+			require.True(t, locked)
+		})
+
+		t.Run("success if freed before timeout ends", func(t *testing.T) {
+			lm := NewLockManager()
+			lock := lm.Access("key")
+			lock.Lock()
+
+			var wg, wgStart sync.WaitGroup
+			wg.Add(1)
+			wgStart.Add(1)
+			go func() {
+				defer wg.Done()
+				lock := lm.Access("key")
+				wgStart.Done()
+				_, locked := lock.LockTimeout(1 * time.Second)
+				if !locked {
+					panic("expected to get the lock")
+				}
+				lock.Unlock()
+			}()
+
+			wgStart.Wait()
+			time.Sleep(50 * time.Microsecond)
+			lock.Unlock()
+			wg.Wait() // <- deadlock if LockTimeout did not succeed
+		})
+
+		t.Run("fail if taken and no timeout", func(t *testing.T) {
+			lm := NewLockManager()
+			l1, l2 := lm.Access("key"), lm.Access("key")
+			l1.Lock()
+			defer l1.Unlock()
+
+			_, locked := l2.LockTimeout(0)
+			assert.False(t, locked)
+		})
+
+		t.Run("fail after timeout", func(t *testing.T) {
+			lm := NewLockManager()
+			l1, l2 := lm.Access("key"), lm.Access("key")
+			l1.Lock()
+			defer l1.Unlock()
+
+			_, locked := l2.LockTimeout(50 * time.Millisecond)
+			assert.False(t, locked)
+		})
+	})
+
+	t.Run("lock with context", func(t *testing.T) {
+		t.Run("success if context is not cancelled", func(t *testing.T) {
+			lm := NewLockManager()
+			l := lm.Access("key")
+			_, err := l.LockContext(context.Background())
+			require.NoError(t, err)
+			l.Unlock()
+		})
+
+		t.Run("fail if context was already cancelled", func(t *testing.T) {
+			lm := NewLockManager()
+			l := lm.Access("key")
+			ctx, cancelFn := context.WithCancel(context.Background())
+			cancelFn()
+			_, err := l.LockContext(ctx)
+			require.Equal(t, ctx.Err(), err)
+		})
+
+		t.Run("fail if context gets cancelled while we are waiting", func(t *testing.T) {
+			lm := NewLockManager()
+			l1, l2 := lm.Access("key"), lm.Access("key")
+
+			l1.Lock()
+			defer l1.Unlock()
+
+			ctx, cancelFn := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancelFn()
+			_, err := l2.LockContext(ctx)
+			assert.Equal(t, ctx.Err(), err)
+		})
+	})
+
+	t.Run("still need to unlock after forced lock release", func(t *testing.T) {
+		t.Run("panics if we attempt to lock right away", func(t *testing.T) {
+			lm := NewLockManager()
+			l := lm.Access("key")
+			session := l.Lock()
+			lm.ForceUnlock("key")
+
+			<-session.LockLost() // wait for signal before trying to lock again
+			expectPanic(t, func() {
+				l.Lock()
+			})
+		})
+
+		t.Run("unlock does succeed", func(t *testing.T) {
+			lm := NewLockManager()
+			l := lm.Access("key")
+			session := l.Lock()
+			lm.ForceUnlock("key")
+
+			<-session.LockLost() // wait for signal before trying to lock again
+			l.Unlock()
+		})
+	})
+
+	t.Run("check ForceUnlockAll", func(t *testing.T) {
+		lm := NewLockManager()
+		l1, l2 := lm.Access("key1"), lm.Access("key2")
+		s1, s2 := l1.Lock(), l2.Lock()
+		defer l1.Unlock()
+		defer l2.Unlock()
+		lm.ForceUnlockAll()
+		<-s1.LockLost()
+		<-s2.LockLost()
+	})
+
+	t.Run("signaling", func(t *testing.T) {
+		const sigUnlocked = 1
+		const sigForced = 2
+
+		waitDone := func(session *LockSession, fn func()) {
+			<-session.Done()
+			fn()
+		}
+
+		waitSignal := func(resp chan int, session *LockSession) {
+			select {
+			case <-session.Unlocked():
+				resp <- sigUnlocked
+			case <-session.LockLost():
+				resp <- sigForced
+			}
+		}
+
+		t.Run("lock session reports done on unlock", func(t *testing.T) {
+			lm := NewLockManager()
+			lock := lm.Access("key")
+			session := lock.Lock()
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go waitDone(session, wg.Done)
+
+			lock.Unlock()
+			wg.Wait() // <- deadlock if signal is not send to session
+		})
+
+		t.Run("lock session reports 'unlocked'", func(t *testing.T) {
+			lm := NewLockManager()
+			lock := lm.Access("key")
+			session := lock.Lock()
+
+			resp := make(chan int)
+			go waitSignal(resp, session)
+
+			lock.Unlock()
+			assert.Equal(t, sigUnlocked, <-resp)
+		})
+	})
+}


### PR DESCRIPTION
Add LockManager to the unison package. The API/functionality provided by the LockManager  is similar to a distributed lock manager. Locks belong to a LockManager  and can be lost anytime, because the lock manager (or some other process) is forcing the lock to loose it's current status. This can be used to cancel/transfer operations between go-routines.