### PR TITLE
Fix LockContext

### DIFF
--- a/unison/mutex.go
+++ b/unison/mutex.go
@@ -91,6 +91,12 @@ func (c Mutex) LockTimeout(duration time.Duration) bool {
 // returned by context.Err, which MUST NOT return nil after cancellation.
 func (c Mutex) LockContext(context doneContext) error {
 	select {
+	case <-context.Done():
+		return context.Err()
+	default:
+	}
+
+	select {
 	case <-c.ch:
 		return nil
 	case <-context.Done():

--- a/unison/mutex_test.go
+++ b/unison/mutex_test.go
@@ -102,6 +102,13 @@ func testLockedFails(t *testing.T, create func() Mutex) {
 		go cancel()
 		assert.Equal(t, context.Canceled, m.LockContext(ctx))
 	})
+
+	t.Run("lock with already cancalled context", func(t *testing.T) {
+		m := create()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		assert.Equal(t, context.Canceled, m.LockContext(ctx))
+	})
 }
 
 func testUnlockedFails(t *testing.T, create func() Mutex) {

--- a/unison/mutex_test.go
+++ b/unison/mutex_test.go
@@ -74,9 +74,16 @@ func testInitializedMutex(t *testing.T) {
 
 	t.Run("lock unlocked with context succeeds", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		go cancel()
+		defer cancel()
 		m := MakeMutex()
 		assert.Equal(t, nil, m.LockContext(ctx))
+	})
+
+	t.Run("locking unlocked mutex with cancelled context fails", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m := MakeMutex()
+		assert.Equal(t, context.Canceled, m.LockContext(ctx))
 	})
 }
 


### PR DESCRIPTION
fix Mutex.LockContext to return early if the given context has already
been released. Without the precheck the mutex still was locked, although
the context was cancelled.