### PR TITLE
Add some more helpers to ctxtool

### DIFF
--- a/ctxtool/cancel.go
+++ b/ctxtool/cancel.go
@@ -1,6 +1,13 @@
 package ctxtool
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+type cancelContext struct {
+	canceller
+}
 
 // AutoCancel collects cancel functions to be executed at the end of the
 // function scope.
@@ -34,4 +41,18 @@ func (ac *AutoCancel) Add(fn context.CancelFunc) {
 func (ac *AutoCancel) With(ctx context.Context, cancel context.CancelFunc) context.Context {
 	ac.Add(cancel)
 	return ctx
+}
+
+// FromCanceller creates a new context from a canceller. If a contex is passed,
+// then Deadline and Value will be ignored.
+func FromCanceller(c canceller) context.Context {
+	return cancelContext{c}
+}
+
+func (c cancelContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (c cancelContext) Value(key interface{}) interface{} {
+	return nil
 }

--- a/ctxtool/channel.go
+++ b/ctxtool/channel.go
@@ -58,11 +58,6 @@ func (c chanContext) Done() <-chan struct{} {
 	return c
 }
 
-// If Done is not yet closed, Err returns nil.
-// If Done is closed, Err returns a non-nil error explaining why:
-// Canceled if the context was canceled
-// or DeadlineExceeded if the context's deadline passed.
-// After Err returns a non-nil error, successive calls to Err return the same error.
 func (c chanContext) Err() error {
 	select {
 	case <-c:

--- a/ctxtool/channel.go
+++ b/ctxtool/channel.go
@@ -19,14 +19,22 @@ package ctxtool
 
 import (
 	"context"
+	"time"
 )
 
 type chanCanceller <-chan struct{}
+
+type chanContext <-chan struct{}
 
 // WithChannel creates a context that is cancelled if the parent context is cancelled
 // or if the given channel is closed.
 func WithChannel(parent context.Context, ch <-chan struct{}) (context.Context, context.CancelFunc) {
 	return MergeCancellation(parent, chanCanceller(ch))
+}
+
+// FromChannel creates a new context from a channel.
+func FromChannel(ch <-chan struct{}) context.Context {
+	return chanContext(ch)
 }
 
 func (c chanCanceller) Done() <-chan struct{} {
@@ -40,4 +48,30 @@ func (c chanCanceller) Err() error {
 	default:
 		return nil
 	}
+}
+
+func (c chanContext) Deadline() (deadline time.Time, ok bool) {
+	return time.Time{}, false
+}
+
+func (c chanContext) Done() <-chan struct{} {
+	return c
+}
+
+// If Done is not yet closed, Err returns nil.
+// If Done is closed, Err returns a non-nil error explaining why:
+// Canceled if the context was canceled
+// or DeadlineExceeded if the context's deadline passed.
+// After Err returns a non-nil error, successive calls to Err return the same error.
+func (c chanContext) Err() error {
+	select {
+	case <-c:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c chanContext) Value(key interface{}) interface{} {
+	return nil
 }


### PR DESCRIPTION
- Add FromChannel and FromCanceller, to create a new context without
merging with an existing context.
- introduce cancelOverwriteContext to not start a go-routine if the
  give context.Context does not support cancelation