### PR TITLE
Add unison.Multierrgroup

### DIFF
--- a/unison/multierrgroup.go
+++ b/unison/multierrgroup.go
@@ -1,0 +1,41 @@
+package unison
+
+import (
+	"context"
+	"sync"
+)
+
+// MultiErrGroup is a collection of goroutines working on subtasks
+// concurrently.  The group waits until all subtasks have finished and collects
+// all errors encountered.
+//
+// The zero value of MultiErrGroup is a valid group.
+type MultiErrGroup struct {
+	mu   sync.Mutex
+	errs []error
+	wg   sync.WaitGroup
+}
+
+// Go starts a new go-routine, collecting errors encounted into the
+// MultiErrGroup.
+func (g *MultiErrGroup) Go(fn func() error) {
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		err := fn()
+		if err != nil && err != context.Canceled {
+			g.mu.Lock()
+			defer g.mu.Unlock()
+			g.errs = append(g.errs, err)
+		}
+	}()
+}
+
+// Wait waits until all go-routines have been stopped and returns all errors
+// encountered.
+func (g *MultiErrGroup) Wait() []error {
+	g.wg.Wait()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.errs
+}

--- a/unison/multierrgroup_test.go
+++ b/unison/multierrgroup_test.go
@@ -13,7 +13,7 @@ func TestMultiErrGroup(t *testing.T) {
 		assert.Equal(t, 0, len(grp.Wait()))
 	})
 
-	t.Run("returns empty list of no routine failed", func(t *testing.T) {
+	t.Run("returns empty list if no go-routine failed", func(t *testing.T) {
 		var grp MultiErrGroup
 		grp.Go(func() error { return nil })
 		assert.Equal(t, 0, len(grp.Wait()))

--- a/unison/multierrgroup_test.go
+++ b/unison/multierrgroup_test.go
@@ -1,0 +1,28 @@
+package unison
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultiErrGroup(t *testing.T) {
+	t.Run("returns empty list if no go-routine was started", func(t *testing.T) {
+		var grp MultiErrGroup
+		assert.Equal(t, 0, len(grp.Wait()))
+	})
+
+	t.Run("returns empty list of no routine failed", func(t *testing.T) {
+		var grp MultiErrGroup
+		grp.Go(func() error { return nil })
+		assert.Equal(t, 0, len(grp.Wait()))
+	})
+
+	t.Run("Returns multiple errors", func(t *testing.T) {
+		var grp MultiErrGroup
+		grp.Go(func() error { return errors.New("1") })
+		grp.Go(func() error { return errors.New("2") })
+		assert.Equal(t, 2, len(grp.Wait()))
+	})
+}


### PR DESCRIPTION
MultiErrGroup is a group of goroutines each working on its own sub-task, independent of other tasks. The group returns every error encountered after shutdown. Only `context.Cancelled` errors will be ignored.

This type is somewhat similar to `errgroup.Group`, but collects all errors and has no builtin support for cancellation of sub-tasks on error. If cancellation is wanted, it needs to be added explictely like this (errgroup require one to setup the group via `errgroup.WithContext` to get a similar behavior):

```
var ctx, cancel := context.WithCancel(context.Background())
defer cancel()

var grp MultiErrGroup
grp.Go(func() (err error) {
    if err = runTask(ctx); err != nil {
      cancel()
    }
    return err
  }()
})

errs := grp.Wait()
```