### PR TITLE
Do not wrap if already context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- FromCancel returns original context.Context, if input implements this type. Deadline and Value will not be ignored anymore. (#22)
+
 ### Deprecated
 
 ### Removed

--- a/ctxtool/cancel.go
+++ b/ctxtool/cancel.go
@@ -46,6 +46,9 @@ func (ac *AutoCancel) With(ctx context.Context, cancel context.CancelFunc) conte
 // FromCanceller creates a new context from a canceller. If a contex is passed,
 // then Deadline and Value will be ignored.
 func FromCanceller(c canceller) context.Context {
+	if ctx, ok := c.(context.Context); ok {
+		return ctx
+	}
 	return cancelContext{c}
 }
 

--- a/ctxtool/cancel.go
+++ b/ctxtool/cancel.go
@@ -43,8 +43,8 @@ func (ac *AutoCancel) With(ctx context.Context, cancel context.CancelFunc) conte
 	return ctx
 }
 
-// FromCanceller creates a new context from a canceller. If a contex is passed,
-// then Deadline and Value will be ignored.
+// FromCanceller creates a new context from a canceller. If a value that
+// implements contex.Context is passed, then the value will be returned as is.
 func FromCanceller(c canceller) context.Context {
 	if ctx, ok := c.(context.Context); ok {
 		return ctx


### PR DESCRIPTION
The FromCanceler creates a context from an interface implementing a
subset of function provided by context.Context. Instead of always
wrapping lets see if we can cast and omitt the wrapping/allocation in
this case.