### PR TITLE
Add error return to Periodic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Update `timed.Period` to return an error. The callback is required to return an error as well. (#28)
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
This change allows the callback used by Periodic to directly stop the
loop, by returning an error. This makes it easier to use Periodic, as
users don't need to setup a temporary context to break the loop anymore.

Periodic now returns an error itself, which is either the error from the
callback or ctx.Err, if the loop was cancelled before the callback has
been run