### PR TITLE
Taskgroup: do not error on Cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix TaskGroup reporting context.Cancel as error. (#30)
+
 ## [0.0.3]
 
 ### Added


### PR DESCRIPTION
The TaskGroup will now swallow context.Cancel if a function returns with
said error value, due to a computation getting cancelled. The error is
not added to the error array anymore, and StopOnError callback will not
be run anymore if individual go-routines get cancelled.