### PR TITLE
Introduct osctx.WithSignal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add `osctx.WithSignal` utility function, which creates a context that will be cancelled if the process receives an os.Signal. (#31)
+
 ### Changed
 
 ### Deprecated

--- a/ctxtool/osctx/osctx.go
+++ b/ctxtool/osctx/osctx.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package osctx
 
 import (

--- a/ctxtool/osctx/osctx.go
+++ b/ctxtool/osctx/osctx.go
@@ -1,0 +1,49 @@
+package osctx
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+// WithSignal creates a context that will be cancelled if any of the configured
+// signals is received by the process. The signal handler will be removed automatically in case the parent context
+// gets cancelled or when the cancel function is called.
+//
+// The context should be used to trigger application shutdown. If the signal is
+// received again, the signal handler will force shutdown the process with exit
+// code 3.
+//
+// example:
+//
+//  func main() {
+//		ctx, cancel := osctx.WithSignal(context.Background(), os.Kill)
+//		defer cancel()
+//
+//		for ctx.Err == nil {
+//			// main run loop
+//		}
+//  }
+func WithSignal(ctx context.Context, sigs ...os.Signal) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	ch := make(chan os.Signal, 1)
+	go func() {
+		defer func() {
+			signal.Stop(ch)
+			cancel()
+		}()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+			cancel()
+			// force shutdown in case we receive another signal
+			<-ch
+			os.Exit(3)
+		}
+	}()
+
+	signal.Notify(ch, sigs...)
+	return ctx, cancel
+}

--- a/ctxtool/osctx/osctx_test.go
+++ b/ctxtool/osctx/osctx_test.go
@@ -1,0 +1,38 @@
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package osctx
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func TestWithSignal(t *testing.T) {
+	t.Run("quit if parent context is cancelled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		ctx, cancel := WithSignal(parent, os.Interrupt)
+		defer cancel()
+
+		<-ctx.Done() // must not block
+	})
+
+	t.Run("return on explicit cancel", func(t *testing.T) {
+		ctx, cancel := WithSignal(context.Background(), os.Interrupt)
+		cancel()
+		<-ctx.Done() // must not block
+	})
+
+	t.Run("quit on signal", func(t *testing.T) {
+		testSignal := syscall.SIGUSR1
+
+		ctx, cancel := WithSignal(context.Background(), testSignal)
+		defer cancel()
+
+		syscall.Kill(syscall.Getpid(), testSignal)
+		<-ctx.Done() // must not block, as the signal has been delivered.
+	})
+}

--- a/ctxtool/osctx/osctx_test.go
+++ b/ctxtool/osctx/osctx_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package osctx


### PR DESCRIPTION
Introduct `osctx.WithSignal`, which creates a context that gets cancelled when an os.Signal is received. Using `WithCancel` can use `context.Context` as basis for application shutdown signal propagation method.