### PR TITLE
Improve context.Context convenience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Added SafeWaitGroupWithCancel constructor that registers the SafeWaitGroup
+  with a context.Context in order to signal 'Close'. #39
+- Added TaskGroupWithCancel constructor that registers the TaskGroup with a
+  context.Context in order to signal 'Close'. #39
+
 ### Changed
+
+- Many helpers in ctxtool now accept a simplified interface that only
+  implements `Done()` and `Err()`, to simplify use if ctxtool is used to
+  integrate with other types then context.Context. If the input type is already
+  context.Context, its type and functionality (Value, Deadline) are preserved.
+  #39
 
 ### Deprecated
 

--- a/ctxtool/cancel.go
+++ b/ctxtool/cancel.go
@@ -55,9 +55,9 @@ func (ac *AutoCancel) Add(fn context.CancelFunc) {
 // With is used to wrap a Context constructer call that returns a context and a
 // cancel function.  The cancel function is automatically added to AutoCancel
 // and the original context is returned as is.
-func (ac *AutoCancel) With(ctx context.Context, cancel context.CancelFunc) context.Context {
+func (ac *AutoCancel) With(ctx canceller, cancel context.CancelFunc) context.Context {
 	ac.Add(cancel)
-	return ctx
+	return FromCanceller(ctx)
 }
 
 // FromCanceller creates a new context from a canceller. If a value that

--- a/ctxtool/channel.go
+++ b/ctxtool/channel.go
@@ -28,7 +28,7 @@ type chanContext <-chan struct{}
 
 // WithChannel creates a context that is cancelled if the parent context is cancelled
 // or if the given channel is closed.
-func WithChannel(parent context.Context, ch <-chan struct{}) (context.Context, context.CancelFunc) {
+func WithChannel(parent canceller, ch <-chan struct{}) (context.Context, context.CancelFunc) {
 	return MergeCancellation(parent, chanCanceller(ch))
 }
 

--- a/ctxtool/func.go
+++ b/ctxtool/func.go
@@ -31,7 +31,9 @@ type funcContext struct {
 
 // WithFunc creates a context that will execute the given function when the
 // parent context gets cancelled.
-func WithFunc(ctx context.Context, fn func()) (context.Context, context.CancelFunc) {
+func WithFunc(parent canceller, fn func()) (context.Context, context.CancelFunc) {
+	ctx := FromCanceller(parent)
+
 	if ctx.Err() != nil {
 		// context already cancelled, call fn
 		go fn()

--- a/ctxtool/merge.go
+++ b/ctxtool/merge.go
@@ -63,7 +63,9 @@ func MergeContexts(ctx1, ctx2 context.Context) (context.Context, context.CancelF
 
 // MergeCancellation creates a new context that will be cancelled if one of the
 // two input contexts gets canceled. The `Values` and `Deadline` are taken from the first context.
-func MergeCancellation(ctx context.Context, other canceller) (context.Context, context.CancelFunc) {
+func MergeCancellation(parent, other canceller) (context.Context, context.CancelFunc) {
+	ctx := FromCanceller(parent)
+
 	err := ctx.Err()
 	if err == nil {
 		err = other.Err()

--- a/ctxtool/osctx/osctx.go
+++ b/ctxtool/osctx/osctx.go
@@ -21,6 +21,9 @@ import (
 	"context"
 	"os"
 	"os/signal"
+
+	"github.com/elastic/go-concert/ctxtool"
+	"github.com/elastic/go-concert/unison"
 )
 
 // WithSignal creates a context that will be cancelled if any of the configured
@@ -41,8 +44,8 @@ import (
 //			// main run loop
 //		}
 //  }
-func WithSignal(ctx context.Context, sigs ...os.Signal) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(ctx)
+func WithSignal(parent unison.Canceler, sigs ...os.Signal) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctxtool.FromCanceller(parent))
 	ch := make(chan os.Signal, 1)
 	go func() {
 		defer func() {

--- a/unison/safewaitgroup.go
+++ b/unison/safewaitgroup.go
@@ -18,8 +18,11 @@
 package unison
 
 import (
+	"context"
 	"errors"
 	"sync"
+
+	"github.com/elastic/go-concert/ctxtool"
 )
 
 // SafeWaitGroup provides a safe alternative to WaitGroup, that instead of
@@ -27,12 +30,24 @@ import (
 type SafeWaitGroup struct {
 	mu     sync.RWMutex
 	wg     sync.WaitGroup
+	cancel context.CancelFunc
 	closed bool
 }
 
 // ErrGroupClosed indicates that the WaitGroup is currently closed, and no more
 // routines can be started.
 var ErrGroupClosed = errors.New("group closed")
+
+// SafeWaitGroupWithCancel creates a SafeWaitGroup that will be closed when
+// the given canceler signals shutdown.
+//
+// Associated resources are cleaned when the parent context is cancelled, or Stop is called.
+func SafeWaitGroupWithCancel(parent Canceler) *SafeWaitGroup {
+	grp := &SafeWaitGroup{}
+	_, cancel := ctxtool.WithFunc(parent, grp.Close)
+	grp.cancel = cancel
+	return grp
+}
 
 // Add adds the delta to the WaitGroup counter.
 // If the counter becomes 0, all goroutines are blocked on Wait will continue.
@@ -64,9 +79,23 @@ func (s *SafeWaitGroup) Done() {
 // close has been called. Close does not wait until the WaitGroup counter has
 // reached zero, but will return immediately. Use Wait to wait for the counter to become 0.
 func (s *SafeWaitGroup) Close() {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.closed = true
+	// When the context is cancelled, either by the parent context or by calling
+	// 'cancel' directly, Close will be called.
+	// The `cancel` function must always be called in order to clean up the context resources.
+	// Due to `cancel` calling `Close`, we better be sure to have the mutex
+	// released before calling cancel.
+	// Although `cancel` is likely to be run in another go-routine, we don't want
+	// to make any assumptions about implementation details of the context and cancel function.
+	var wasClosed bool
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		wasClosed, s.closed = s.closed, true
+	}()
+
+	if !wasClosed && s.cancel != nil {
+		s.cancel()
+	}
 }
 
 // Wait closes the WaitGroup and blocks until the WaitGroup counter is zero.


### PR DESCRIPTION
The functions in the ctxtool package have been adapted to accept a "reduced" interface (oftentimes just canceler), but always return a context.Context. If the input type is indeed a `context.Context`, the original context will be used. Otherwise the input type will be adapted automatically.
If one has a type that signals cancellation only, one can now write `ctxtool.WithFunc(parent, func() {})` instead of `ctxtool.WithFunc(ctxtool.FromCanceler(parent), func() {})`.


The SafeWaitGroup and TaskGroup now introduce constructors that accept a `Cancler` in order to signal shutdown asynchronously more easily.

Instead of 

```
var swg SafeWaitGroup
defer swg.Wait()

_, cancel := ctxtool.WithFunc(parent, func() { swg.Stop() })
defer cancel()

```

One can now write:

```
swg := SafeWaitGroupWithCancel(parent)
defer swg.Wait()
```

Similar for TaskGroup, instead of

```
var tg TaskGroup

_, cancel := ctxtool.WithFunc(parent, func() { tg.Stop() })
defer cancel()
```

one can now write:

```
tg := TaskGroupWithCancel(parent)
...
```

If possible one still should call Stop. This change is only convenient when TaskGroup must outlive the current function. It is preferable if a TaskGroup only exists in the context of the current function call. In that case one recommended pattern is:

```
var tg TaskGroup

tg.Go(func(c Canceler) error {
   ...
})

<-parent.Done()
err := tg.Stop()
```