### PR TITLE
Add CancelContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   with a context.Context in order to signal 'Close'. #39
 - Added TaskGroupWithCancel constructor that registers the TaskGroup with a
   context.Context in order to signal 'Close'. #39
+- Added `CancelContext`, `WithCancelContext`, and `WrapCancel` in order to combine
+  a `context.Context` and a `context.CancelFunc` into a common struct that can be
+  stored as a single field in a struct. (#41)
 
 ### Changed
 

--- a/ctxtool/cancel_test.go
+++ b/ctxtool/cancel_test.go
@@ -46,3 +46,31 @@ func TestAutoCancel(t *testing.T) {
 		assert.Error(t, ctx.Err())
 	})
 }
+
+func TestCancelContext(t *testing.T) {
+	t.Run("canceled if parent is canceled", func(t *testing.T) {
+		parent, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		ctx := WithCancelContext(parent)
+		defer ctx.Cancel()
+		<-ctx.Done()
+	})
+
+	t.Run("cancellation", func(t *testing.T) {
+		ctx := WithCancelContext(context.TODO())
+		ctx.Cancel()
+		<-ctx.Done()
+	})
+
+	t.Run("wrap", func(t *testing.T) {
+		ctx := WrapCancel(context.WithCancel(context.TODO()))
+		ctx.Cancel()
+		<-ctx.Done()
+	})
+
+	t.Run("no panic if nil cancel", func(t *testing.T) {
+		ctx := WrapCancel(context.TODO(), nil)
+		ctx.Cancel()
+	})
+}


### PR DESCRIPTION
Introduce CancelContext that stores a context and it's CancelFunc. This makes a little less verbose in case a context and its cancel func need to be stored in a struct.


For example:

```
cancelCtx := ctxtool.WithCancelContext(parent)
defer cancelCtx.Cancel()

...
```


for context helpers beyond `context` it is not uncommon to return a cancel function that is required to clean up resources. The Canceler type can be used to wrap such contexts:


```
cancelCtx := ctxtool.WrapCancel(context.WithCancel(parent))
```