### PR TITLE
Add Cell type to unison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `CancelContext`, `WithCancelContext`, and `WrapCancel` in order to combine
   a `context.Context` and a `context.CancelFunc` into a common struct that can be
   stored as a single field in a struct. (#41)
+- Add `unison.Cell` type. A cell stores states that can be updated
+  asynchronously without back-pressure (unlike a channel). Consumers can read the current state
+  or wait for new updates. (#44)
 
 ### Changed
 

--- a/unison/cell.go
+++ b/unison/cell.go
@@ -17,6 +17,8 @@
 
 package unison
 
+import "sync"
+
 // Cell stores some state of type interface{}.
 // Intermittent updates are lost, in case the Cell is updated faster than the
 // consumer tries to read for state updates. Updates are immediate, there will
@@ -26,9 +28,11 @@ package unison
 // absolute state must be computed by the producer beforehand.
 //
 // A typical use-case for cell is to generate asynchronous configuration updates (no deltas).
+//
+// The zero value of Cell is valid, but a value of type Cell can not be copied.
 type Cell struct {
 	// All writes/reads to any of the internal fields must be guarded by mu.
-	mu Mutex
+	mu sync.Mutex
 
 	// logical config state update counters.
 	// The readID always follows writeID. We are using the most recent state
@@ -44,10 +48,7 @@ type Cell struct {
 // NewCell creates a new call instance with its initial state. Subsequent reads
 // will return this state, if there have been no updates.
 func NewCell(st interface{}) *Cell {
-	return &Cell{
-		mu:    MakeMutex(),
-		state: st,
-	}
+	return &Cell{state: st}
 }
 
 // Get returns the current state.

--- a/unison/cell.go
+++ b/unison/cell.go
@@ -1,0 +1,114 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unison
+
+// Cell stores some state of type interface{}.
+// Intermittent updates are lost, in case the Cell is updated faster than the
+// consumer tries to read for state updates. Updates are immediate, there will
+// be no backpressure applied to producers.
+//
+// In case the Cell is used to transmit updates without backpressure, the
+// absolute state must be computed by the producer beforehand.
+//
+// A typical use-case for cell is to generate asynchronous configuration updates (no deltas).
+type Cell struct {
+	// All writes/reads to any of the internal fields must be guarded by mu.
+	mu Mutex
+
+	// logical config state update counters.
+	// The readID always follows writeID. We are using the most recent state
+	// update if readID == waitID.
+	writeID uint64
+	readID  uint64
+
+	state interface{}
+
+	waiter chan struct{}
+}
+
+// NewCell creates a new call instance with its initial state. Subsequent reads
+// will return this state, if there have been no updates.
+func NewCell(st interface{}) *Cell {
+	return &Cell{
+		mu:    MakeMutex(),
+		state: st,
+	}
+}
+
+// Get returns the current state.
+func (c *Cell) Get() interface{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.read()
+}
+
+// Wait blocks until it an update since the last call to Get or Wait has been found.
+// The cancel context can be used to interrupt the call to Wait early. The
+// error value will be set to the value returned by cancel.Err() in case Wait
+// was interrupted. Wait does not produce any errors that need to be handled by itself.
+func (c *Cell) Wait(cancel Canceler) (interface{}, error) {
+	c.mu.Lock()
+
+	if c.readID != c.writeID {
+		defer c.mu.Unlock()
+		return c.read(), nil
+	}
+
+	var waiter chan struct{}
+	if c.waiter == nil {
+		waiter = make(chan struct{})
+		c.waiter = waiter
+	} else {
+		waiter = c.waiter
+	}
+	c.mu.Unlock()
+
+	select {
+	case <-cancel.Done():
+		// we don't bother to check the waiter channel again. Cancellation if
+		// detected has priority.
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.waiter = nil
+		return nil, cancel.Err()
+	case <-waiter:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.read(), nil
+	}
+}
+
+// Set updates the state of the Cell and unblocks a waiting consumer.
+// Set does not block.
+func (c *Cell) Set(st interface{}) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.writeID++
+	c.state = st
+
+	if c.waiter != nil {
+		close(c.waiter)
+		c.waiter = nil
+	}
+}
+
+func (c *Cell) read() interface{} {
+	c.readID = c.writeID
+	return c.state
+}

--- a/unison/cell_test.go
+++ b/unison/cell_test.go
@@ -1,0 +1,137 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package unison
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCell(t *testing.T) {
+	t.Run("read state from init", func(t *testing.T) {
+		cell := NewCell("init")
+		assert.Equal(t, "init", cell.Get())
+	})
+
+	t.Run("sync update cell", func(t *testing.T) {
+		cell := NewCell("init")
+		cell.Set("test")
+		assert.Equal(t, "test", cell.Get())
+	})
+
+	t.Run("Wait does not block after set", func(t *testing.T) {
+		cell := NewCell("init")
+		cell.Set("test")
+
+		val, err := cell.Wait(context.TODO())
+		assert.NoError(t, err)
+		assert.Equal(t, "test", val)
+	})
+
+	t.Run("cancel wait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.TODO())
+		cancel()
+
+		cell := NewCell("init")
+		_, err := cell.Wait(ctx)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	t.Run("wait for update", func(t *testing.T) {
+		cell := NewCell("init")
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			time.Sleep(100 * time.Millisecond)
+			cell.Set("test")
+		}()
+
+		val, err := cell.Wait(context.Background())
+		assert.NoError(t, err)
+		assert.Equal(t, "test", val)
+	})
+}
+
+// ExampleCellACK tracks the number of ACKed events without backpressure in the
+// generating thread, even if the consumer is blocked. The consumer computes
+func ExampleCell_acking() {
+	type exampleACKer struct {
+		state      *Cell
+		ackedWrite uint
+		ackedRead  uint
+	}
+
+	// exampleACK acks a single event by updating the 'absolute' state.
+	// The function return immediately, even if the "reader" process is
+	// blocking for a long time.
+	exampleACK := func(acker *exampleACKer) {
+		acker.ackedWrite++
+		acker.state.Set(acker.ackedWrite)
+	}
+
+	// exampleWaitACKed waits for state changes and returns the number of
+	// events that have been acked since the last read. It returns the accumulated state.
+	exampleWaitACKed := func(acker *exampleACKer, ctx context.Context) (uint, error) {
+		st, err := acker.state.Wait(ctx)
+		if err != nil {
+			return 0, err
+		}
+
+		v := st.(uint)
+		acker.ackedRead, v = v, v-acker.ackedRead
+		return v, nil
+	}
+
+	const max = 100
+	acker := &exampleACKer{state: NewCell(0)}
+
+	// start go-routine that ACKs single events
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	wg.Add(1)
+	go func() { // ACKer thread
+		defer wg.Done()
+
+		// We ACK event by event, but merge the overall state
+		// by reporting the absolute value.
+		for send := 0; send < max; send++ {
+			exampleACK(acker)
+		}
+	}()
+
+	// reader loop
+	var totalACKed uint
+	for totalACKed < max {
+		acked, _ := exampleWaitACKed(acker, context.TODO())
+
+		// Handle 'N" events being ACKed
+		totalACKed += acked
+	}
+
+	fmt.Println("Total:", totalACKed)
+	// Output: Total: 100
+}


### PR DESCRIPTION
Introduce `unison.Cell` type. The implementation has been copied from collector prototype.

A Cell stores state that can be updates asynchronously. A reader go-routine can wait for state updates, without creating back-pressure on the producer in case the reader thread is slowed down.

The type is used by the collector prototype to reduce back-pressure induced by registry update on [ACK handling](https://github.com/urso/beats/blob/collector/x-pack/collector/internal/pipeline/ack.go#L21) and to [apply configuration updates](https://github.com/urso/beats/blob/collector/x-pack/collector/internal/pipeline/controller.go#L169).
