### PR TITLE
Update CI go versions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         axes {
           axis {
             name 'GO_VERSION'
-            values '1.13.15', '1.14.13'
+            values '1.14.14', '1.15.7', '1.16beta1'
           }
           axis {
             name 'PLATFORM'


### PR DESCRIPTION
Update CI to use the maintained and upcoming go version 1.14, 1.15, and 1.16 (still beta).