### PR TITLE
Improve Taskgroup ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `(*TaskGroup).Go` will now pass `context.Context` to the run function. (#48)
 - `TaskGroup.StopOnError` has been superseded by `TaskGroup.OnQuit`. (#48)
+- `TaskGroup` will now shutdown by default if a managed go-routine did return an error. (#48)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `(*TaskGroup.Context()` returns the groups internal Context. (#48)
+- `(*TaskGroup).Wait()` waits for all managed go routines to return. (#48)
+- `TaskGroup.MaxError`configures the maxium number of errors to keep. The
+  last N errors will be reported. (#48)
+- Introduce support for configurable group stop behavior via `OnQuit`
+  callbacks. Provided strategies: `ContinueOnErrors`, `RestartOnError`,
+  `StopAll`, `StopOnError`, `StopOnErrorOrCancel`. (#48)
+
 ### Changed
+
+- `(*TaskGroup).Go` will now pass `context.Context` to the run function. (#48)
+- `TaskGroup.StopOnError` has been superseded by `TaskGroup.OnQuit`. (#48)
 
 ### Deprecated
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/urso/sderr v0.0.0-20200210124243-c2a16f3d43ec
+	github.com/urso/sderr v0.0.0-20210525210834-52b04e8f5c71
 	go.uber.org/goleak v1.0.0
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/tools v0.0.0-20200216192241-b320d3a0f5a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/urso/diag v0.0.0-20200210123136-21b3cc8eb797 h1:OHNw/6pXODJAB32NujjdQ
 github.com/urso/diag v0.0.0-20200210123136-21b3cc8eb797/go.mod h1:pNWFTeQ+V1OYT/TzWpnWb6eQBdoXpdx+H+lrH97/Oyo=
 github.com/urso/sderr v0.0.0-20200210124243-c2a16f3d43ec h1:HkZIDJrMKZHPsYhmH2XjTTSk1pbMCFfpxSnyzZUFm+k=
 github.com/urso/sderr v0.0.0-20200210124243-c2a16f3d43ec/go.mod h1:Wp40HwmjM59FkDIVFfcCb9LzBbnc0XAMp8++hJuWvSU=
+github.com/urso/sderr v0.0.0-20210525205558-6f1d4d39d5d9 h1:3akNuvoWCqInVUORSYVp/mAUu5yHSxqOwTVjJ/Zt5OQ=
+github.com/urso/sderr v0.0.0-20210525205558-6f1d4d39d5d9/go.mod h1:Wp40HwmjM59FkDIVFfcCb9LzBbnc0XAMp8++hJuWvSU=
+github.com/urso/sderr v0.0.0-20210525210834-52b04e8f5c71 h1:CehQeKbysHV8J2V7AD0w8NL2x1h04kmmo/Ft5su4lU0=
+github.com/urso/sderr v0.0.0-20210525210834-52b04e8f5c71/go.mod h1:Wp40HwmjM59FkDIVFfcCb9LzBbnc0XAMp8++hJuWvSU=
 go.uber.org/goleak v1.0.0 h1:qsup4IcBdlmsnGfqyLl4Ntn3C2XCCuKAE7DwHpScyUo=
 go.uber.org/goleak v1.0.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/unison/cell_test.go
+++ b/unison/cell_test.go
@@ -62,7 +62,7 @@ func TestCell(t *testing.T) {
 
 		var tg TaskGroup
 		defer tg.Stop()
-		tg.Go(func(_ Canceler) error {
+		tg.Go(func(_ context.Context) error {
 			time.Sleep(100 * time.Millisecond)
 			cell.Set("updated")
 			return nil
@@ -84,7 +84,7 @@ func TestCell(t *testing.T) {
 
 		var tg TaskGroup
 		defer tg.Stop()
-		tg.Go(func(_ Canceler) error {
+		tg.Go(func(_ context.Context) error {
 			time.Sleep(100 * time.Millisecond)
 			cell.Set("updated")
 			return nil

--- a/unison/taskgroup.go
+++ b/unison/taskgroup.go
@@ -31,7 +31,7 @@ type Group interface {
 	// Go method returns an error if the task can not be started. The error
 	// returned by the task itself is not supposed to be returned, as the error is
 	// assumed to be generated asynchronously.
-	Go(fn func(Canceler) error) error
+	Go(fn func(context.Context) error) error
 }
 
 // Canceler interface, that can be used to pass along some shutdown signal to
@@ -55,7 +55,7 @@ func ClosedGroup(reportedError error) Group {
 	return &closedGroup{err: reportedError}
 }
 
-func (c closedGroup) Go(_ func(Canceler) error) error {
+func (c closedGroup) Go(_ func(context.Context) error) error {
 	return c.err
 }
 
@@ -71,11 +71,22 @@ func (c closedGroup) Go(_ func(Canceler) error) error {
 // The zero value of TaskGroup is fully functional. StopOnError must not be set after
 // the first go-routine has been spawned.
 type TaskGroup struct {
-	// StopOnError  configures the behavior when a sub-task failed. If not set
+	// OnQuit  configures the behavior when a sub-task returned. If not set
 	// all other tasks will continue to run. If the function return true, a
 	// shutdown signal is passed, and Go will fail on attempts to start new
 	// tasks.
-	StopOnError func(err error) bool
+	// Next to the action, does the OnQuit error also return the error value
+	// to be recorded. The context.Cancel error will never be recorded.
+	//
+	// Common OnError handlers are given by ContinueOnErrors, StopOnError,
+	// StopOnErrorOrCancel.
+	// By default ContinueOnErrors will be used.
+	OnQuit TaskGroupQuitHandler
+
+	// MaxErrors configures the maximum amount of errors the TaskGroup will record.
+	// Older errors will be replaced once the limit is exceeded.
+	// If MaxErrors is set to a value < 0, all errors will be recorded.
+	MaxErrors int
 
 	mu   sync.Mutex
 	errs []error
@@ -86,12 +97,38 @@ type TaskGroup struct {
 	cancel   context.CancelFunc
 }
 
+type TaskGroupQuitHandler func(error) (TaskGroupStopAction, error)
+
+// TaskGroupStopAction signals the action to take when a go-routine owned by a
+// TaskGroup did quit.
+type TaskGroupStopAction uint
+
+const (
+	// TaskGroupStopActionContinue notifies the TaskGroup that other managed go-routines
+	// should not be signled to shutdown.
+	TaskGroupStopActionContinue TaskGroupStopAction = iota
+
+	// TaskGroupStopActionShutdown notifies the TaskGroup that shutdown should be signaled
+	// to all maanaged go-routines.
+	TaskGroupStopActionShutdown
+
+	// TaskGroupStopActionRestart signals the TaskGroup that the managed go-routine that has
+	// just been returned should be restarted.
+	TaskGroupStopActionRestart
+)
+
 var _ Group = (*TaskGroup)(nil)
 
 // init initializes internal state the first time the group is actively used.
 func (t *TaskGroup) init(parent Canceler) {
 	t.initOnce.Do(func() {
 		t.closer, t.cancel = context.WithCancel(ctxtool.FromCanceller(parent))
+		if t.OnQuit == nil {
+			t.OnQuit = ContinueOnErrors
+		}
+		if t.MaxErrors == 0 {
+			t.MaxErrors = 10
+		}
 	})
 }
 
@@ -112,7 +149,7 @@ func TaskGroupWithCancel(canceler Canceler) *TaskGroup {
 // Errors returned by the function are collected and finally returned on Stop.
 // If the group was stopped before calling Go, then Go will return the
 // ErrGroupClosed error.
-func (t *TaskGroup) Go(fn func(Canceler) error) error {
+func (t *TaskGroup) Go(fn func(context.Context) error) error {
 	t.init(context.Background())
 
 	if err := t.wg.Add(1); err != nil {
@@ -121,15 +158,28 @@ func (t *TaskGroup) Go(fn func(Canceler) error) error {
 
 	go func() {
 		defer t.wg.Done()
-		err := fn(t.closer)
-		if err != nil && err != context.Canceled {
-			t.mu.Lock()
-			t.errs = append(t.errs, err)
-			t.mu.Unlock()
 
-			if t.StopOnError != nil && t.StopOnError(err) {
-				t.wg.Close()
-				t.cancel()
+		for t.closer.Err() == nil {
+			err := fn(t.closer)
+			action, err := t.OnQuit(err)
+
+			if err != nil && err != context.Canceled {
+				t.mu.Lock()
+				t.errs = append(t.errs, err)
+				if t.MaxErrors > 0 && len(t.errs) > t.MaxErrors {
+					t.errs = t.errs[1:]
+				}
+				t.mu.Unlock()
+			}
+
+			switch action {
+			case TaskGroupStopActionContinue:
+				return // finish managed go-routine, but keep other routines alive.
+			case TaskGroupStopActionShutdown:
+				t.signalStop()
+				return
+			case TaskGroupStopActionRestart:
+				// continue with loop
 			}
 		}
 	}()
@@ -137,10 +187,28 @@ func (t *TaskGroup) Go(fn func(Canceler) error) error {
 	return nil
 }
 
-func (t *TaskGroup) wait() []error {
+// Context returns the task groups internal context.
+// The internal context will be cancelled if the groups parent context gets
+// cancelled, or Stop has been called.
+func (t *TaskGroup) Context() context.Context {
+	t.init(context.Background())
+	return t.closer
+}
+
+// Wait blocks until all owned child routines have been stopped.
+func (t *TaskGroup) Wait() error {
+	errs := t.waitErrors()
+	if len(errs) > 0 {
+		return sderr.WrapAll(errs, "task failures")
+	}
+	return nil
+}
+
+func (t *TaskGroup) waitErrors() []error {
 	t.wg.Wait()
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
 	return t.errs
 }
 
@@ -148,10 +216,55 @@ func (t *TaskGroup) wait() []error {
 // It returns an error that contains all errors encountered.
 func (t *TaskGroup) Stop() error {
 	t.init(context.Background())
+	t.signalStop()
+	return t.Wait()
+}
+
+// signalStop will cancel the internal context, signaling existing go-routines
+// to shutdown AND invalidate the TaskGroup, such that no new go-routines can
+// be started anymore.
+func (t *TaskGroup) signalStop() {
+	t.wg.Close()
 	t.cancel()
-	errs := t.wait()
-	if len(errs) > 0 {
-		return sderr.WrapAll(errs, "task failures")
+}
+
+// ContinueOnErrors provides a TaskGroup.OnQuit handler, that will ignore
+// any errors. Other go-routines owned by the TaskGroup will continue to run.
+func ContinueOnErrors(err error) (TaskGroupStopAction, error) {
+	return TaskGroupStopActionContinue, err
+}
+
+// RestartOnError provides a TaskGroup.OnQuit handler, that will restart a
+// go-routine if the routine failed with an error.
+func RestartOnError(err error) (TaskGroupStopAction, error) {
+	if err != nil && err != context.Canceled {
+		return TaskGroupStopActionRestart, err
 	}
-	return nil
+	return TaskGroupStopActionContinue, err
+}
+
+// StopAll provides a Taskgroup.OnError handler, that will signal
+// the TaskGroup to shutdown once an owned go-routine returns.
+// The TaskGroup is supposed to stop even on successful return.
+func StopAll(err error) (TaskGroupStopAction, error) {
+	return TaskGroupStopActionShutdown, err
+}
+
+// StopOnError provides a TaskGroup.OnError handler, that will signal the Taskgroup
+// to stop all owned go-routines.
+// The context.Canceled error value will be ignored.
+func StopOnError(err error) (TaskGroupStopAction, error) {
+	if err != nil && err != context.Canceled {
+		return TaskGroupStopActionShutdown, err
+	}
+	return TaskGroupStopActionContinue, err
+}
+
+// StopOnErrorOrCancel provides a TaskGroup.OnError handler, that will signal the Taskgroup
+// to stop all owned go-routines.
+func StopOnErrorOrCancel(err error) (TaskGroupStopAction, error) {
+	if err != nil {
+		return TaskGroupStopActionShutdown, err
+	}
+	return TaskGroupStopActionContinue, err
 }

--- a/unison/taskgroup.go
+++ b/unison/taskgroup.go
@@ -80,7 +80,7 @@ type TaskGroup struct {
 	//
 	// Common OnError handlers are given by ContinueOnErrors, StopOnError,
 	// StopOnErrorOrCancel.
-	// By default ContinueOnErrors will be used.
+	// By default StopOnError will be used.
 	OnQuit TaskGroupQuitHandler
 
 	// MaxErrors configures the maximum amount of errors the TaskGroup will record.
@@ -124,7 +124,7 @@ func (t *TaskGroup) init(parent Canceler) {
 	t.initOnce.Do(func() {
 		t.closer, t.cancel = context.WithCancel(ctxtool.FromCanceller(parent))
 		if t.OnQuit == nil {
-			t.OnQuit = ContinueOnErrors
+			t.OnQuit = StopOnError
 		}
 		if t.MaxErrors == 0 {
 			t.MaxErrors = 10

--- a/unison/taskgroup_test.go
+++ b/unison/taskgroup_test.go
@@ -96,7 +96,7 @@ func TestTaskGroup_MaxErrors(t *testing.T) {
 
 	const numErrors = 5
 	const limit = 3
-	tg := TaskGroup{MaxErrors: limit}
+	tg := TaskGroup{MaxErrors: limit, OnQuit: ContinueOnErrors}
 
 	var errs [numErrors]error
 	for i := 0; i < numErrors; i++ {

--- a/unison/taskgroup_test.go
+++ b/unison/taskgroup_test.go
@@ -20,6 +20,7 @@ package unison
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -29,78 +30,241 @@ import (
 func TestTaskGroup(t *testing.T) {
 	t.Run("stop sends signal to worker", func(t *testing.T) {
 		var grp TaskGroup
-		ch := make(chan bool, 1)
-		err := grp.Go(func(cancel Canceler) error {
+		wg, wgStart := wgCount(1), wgCount(1)
+		err := grp.Go(func(cancel context.Context) error {
+			defer wg.Done()
+			wgStart.Done()
 			<-cancel.Done()
-			ch <- true
 			return nil
 		})
 		require.NoError(t, err)
 
+		wgStart.Wait()
 		err = grp.Stop()
 		require.NoError(t, err)
-		<-ch // this blocks if works did not shut down
+		wg.Wait()
 	})
 
 	t.Run("cancel is no error", func(t *testing.T) {
 		var grp TaskGroup
-		grp.Go(func(_ Canceler) error { return context.Canceled })
+		grp.Go(func(_ context.Context) error { return context.Canceled })
 		require.NoError(t, grp.Stop())
-	})
-
-	t.Run("cancel does not trigger stop", func(t *testing.T) {
-		count := 0
-		grp := TaskGroup{
-			StopOnError: func(_ error) bool { count++; return false },
-		}
-		grp.Go(func(_ Canceler) error { return context.Canceled })
-		grp.Stop()
-
-		require.Equal(t, 0, count)
 	})
 
 	t.Run("can not create go-routine if group has been stopped", func(t *testing.T) {
 		var grp TaskGroup
 		grp.Stop()
-		require.Equal(t, ErrGroupClosed, grp.Go(func(_ Canceler) error { return nil }))
+		require.Equal(t, ErrGroupClosed, grp.Go(func(_ context.Context) error { return nil }))
 	})
 
-	t.Run("stop all tasks on error", func(t *testing.T) {
-		grp := TaskGroup{
-			StopOnError: func(_ error) bool { return true },
-		}
-
-		ch := make(chan bool, 2)
-		grp.Go(func(c Canceler) error {
-			<-c.Done()
-			ch <- true
-			return nil
-		})
-		grp.Go(func(c Canceler) error {
-			ch <- true
-			return errors.New("oops")
-		})
-
-		<-ch
-		<-ch // block if not all workers have been shut down
-
-		// send stop to collect errors
-		require.Error(t, grp.Stop())
-	})
-
-	t.Run("with context", func(t *testing.T) {
+	t.Run("signal shutdown via context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.TODO())
 		grp := TaskGroupWithCancel(ctx)
 
-		var wg sync.WaitGroup // use waitgroup to check the managed go-routine did indeed return
-		wg.Add(1)
-		grp.Go(func(c Canceler) error {
+		wg, wgStart := wgCount(1), wgCount(1)
+		grp.Go(func(c context.Context) error {
 			defer wg.Done()
+			wgStart.Done()
 			<-c.Done()
 			return nil
 		})
 
+		wgStart.Wait()
 		cancel()
 		wg.Wait()
 	})
+
+	t.Run("Context", func(t *testing.T) {
+		t.Run("stop is propogate", func(t *testing.T) {
+			var tg TaskGroup
+			ctx := tg.Context()
+			tg.Stop()
+			require.Equal(t, context.Canceled, ctx.Err())
+		})
+
+		t.Run("parent context shutdown is propagated", func(t *testing.T) {
+			parentCtx, cancel := context.WithCancel(context.TODO())
+			tg := TaskGroupWithCancel(parentCtx)
+			ctx := tg.Context()
+			cancel()
+			require.Equal(t, context.Canceled, ctx.Err())
+		})
+	})
+}
+
+func TestTaskGroup_MaxErrors(t *testing.T) {
+
+	const numErrors = 5
+	const limit = 3
+	tg := TaskGroup{MaxErrors: limit}
+
+	var errs [numErrors]error
+	for i := 0; i < numErrors; i++ {
+		errs[i] = fmt.Errorf("opps: %v", i)
+	}
+
+	for _, err := range errs {
+		wg := wgCount(1)
+		tg.Go(func(_ context.Context) error {
+			defer wg.Done()
+			return err
+		})
+		wg.Wait()
+	}
+
+	want := errs[numErrors-limit:]
+	got := tg.waitErrors()
+	require.Equal(t, want, got)
+}
+
+func TestTaskgroup_OnQuit_ContinueOnError(t *testing.T) {
+	onQuit := ContinueOnErrors
+
+	t.Run("continue on normal return", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, finishedGroupWorker)
+	})
+
+	t.Run("continues on error", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, failingGroupWorker)
+	})
+}
+
+func TestTaskgroup_OnQuit_RestartOnError(t *testing.T) {
+	onQuit := RestartOnError
+
+	t.Run("continue on normal return", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, finishedGroupWorker)
+	})
+
+	t.Run("restarts on error", func(t *testing.T) {
+		var count int
+		grp := TaskGroup{OnQuit: onQuit}
+
+		grp.Go(func(_ context.Context) error {
+			count++
+			t.Log(count)
+			if count == 1 {
+				return errors.New("oops")
+			}
+			return nil
+		})
+
+		grp.Wait()
+		require.Equal(t, 2, count)
+	})
+
+}
+
+func TestTaskgroup_OnQuit_StopAll(t *testing.T) {
+	onQuit := StopAll
+
+	t.Run("stops on normal return", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, finishedGroupWorker)
+	})
+
+	t.Run("stop on cancel", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, internalCancelGroupWorker)
+	})
+
+	t.Run("stop on error", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, failingGroupWorker)
+	})
+}
+
+func TestTaskgroup_OnQuit_StopOnError(t *testing.T) {
+	onQuit := StopOnError
+
+	t.Run("continue on normal return", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, finishedGroupWorker)
+	})
+
+	t.Run("continue on cancel", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, internalCancelGroupWorker)
+	})
+
+	t.Run("stop on error", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, failingGroupWorker)
+	})
+}
+
+func TestTaskgroup_OnQuit_StopOnErrorOrCancel(t *testing.T) {
+	onQuit := StopOnErrorOrCancel
+
+	t.Run("continue on normal return", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupContinuesIf(t, &grp, finishedGroupWorker)
+	})
+
+	t.Run("stop on cancel", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, internalCancelGroupWorker)
+	})
+
+	t.Run("stop on error", func(t *testing.T) {
+		grp := TaskGroup{OnQuit: onQuit}
+		testTaskGroupStopsIf(t, &grp, failingGroupWorker)
+	})
+}
+
+func testTaskGroupContinuesIf(t *testing.T, grp *TaskGroup, fnFirst func(context.Context) error) {
+	wgFirst, wgSecondStart, wgSecondDone := wgCount(1), wgCount(1), wgCount(1)
+	grp.Go(func(ctx context.Context) error {
+		defer wgFirst.Done()
+		return fnFirst(ctx)
+	})
+
+	wgFirst.Wait()
+	require.NoError(t, grp.Go(func(c context.Context) error {
+		defer wgSecondDone.Done()
+		wgSecondStart.Done()
+		<-c.Done()
+		return nil
+	}))
+
+	wgSecondStart.Wait()
+	grp.Stop()
+	wgSecondDone.Wait()
+}
+
+func testTaskGroupStopsIf(t *testing.T, grp *TaskGroup, fnFail func(context.Context) error) {
+	wgStart := wgCount(1)
+	grp.Go(func(ctx context.Context) error {
+		wgStart.Done()
+		<-ctx.Done()
+		return nil
+	})
+
+	grp.Go(func(ctx context.Context) error {
+		wgStart.Wait()
+		return fnFail(ctx)
+	})
+
+	grp.Wait()
+}
+
+func wgCount(n int) *sync.WaitGroup {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	return &wg
+}
+
+func failingGroupWorker(_ context.Context) error {
+	return errors.New("oops")
+}
+
+func finishedGroupWorker(_ context.Context) error {
+	return nil
+}
+
+func internalCancelGroupWorker(_ context.Context) error {
+	return context.Canceled
 }


### PR DESCRIPTION
The `TaskGroup.Go` method will now pass a `context.Context` instead of a `Canceler` to the run function. This makes it a little easier to use the parameter passed to the run function with context specific code. The TaskGroup still is initialized via `Canceler`, in order to support a broader set of input types. If the TaskGroup was initialized with a type implementing `context.Context`, then the internal context passed will be directly derived from that context (Deadline and Value calls are kept
intact).

The TasGroups internal context can be accessed via `TaskGroup.Context()`. The context will be cancelled when the TaskGroup gets cancelled via its parent context, or when Stop is called.

Add `TaskGroup.Wait`. The `Wait` method does not emit a stop signal, but waits until all managed go-routines have been stopped. The `Wait` method returns an error similar to `Wait`. `Wait` is best used in conjunction with a parent context. For example:

```
parentCtx := ...
tg := TaskGroupWithCancel(parentCtx)
tg.Go(...)

return tg.Wait() // blocks until the group has finished by itself or was
cancelled by `parentCtx`.
```

Add `TaskGroup.MaxErrors` field to be initialsed when creating the taskgroup. `MaxErrors` limits the number of errors to be collected by default. Only the last `MaxErrors` errors will be collected and
reported. Setting `MaxErrors` to `-1` will continue to collect all errors ever encountered.

Breaking Change: Replace StopOnError with OnQuit callback.
The OnQuit handler will always be run whenever a managed go-routine returns. The callback decides on a group action (stop group, restart returned function, stop returned function), and computes the error value to report. This way the OnQuit callback can be used to customize the group behavior in case a worker returned early or failed. Out of the box we provide: `ContineOnErrors`, `RestartOnError`,
`StopAll`, `StopOnError`, and `StopOnErrorOrCancel` semantics.
For full control users can create their custom handlers and error types, that can create different actions. This way single error returns from workers will be able to influence the group behavior.