### PR TITLE
Add riscv64 atomic support

### DIFF
--- a/atomic/atomic64.go
+++ b/atomic/atomic64.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x
+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x riscv64
 
 package atomic
 


### PR DESCRIPTION
Add riscv64 support in `atomic/atomic64.go`.