### PR TITLE
ci: use github actions macos

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
           }
           axis {
             name 'PLATFORM'
-            values 'ubuntu-18 && immutable', 'macosx&&x86_64', 'windows-2019 && immutable'
+            values 'ubuntu-18 && immutable', 'windows-2019 && immutable'
           }
         }
         stages {

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: get go version
+      run: |
+        gv=$(cat .go-version)
+        echo "::set-output name=go::$gv"
+      id: version
+
+    - name: install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: "${{steps.version.outputs.go}}"
+
+    - name: Run test
+      run: .ci/test.sh

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
 
+jobs:
   macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,16 +13,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - name: get go version
-      run: |
-        gv=$(cat .go-version)
-        echo "::set-output name=go::$gv"
-      id: version
-
-    - name: install Go
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: "${{steps.version.outputs.go}}"
+        go-version: '>=1.17.0'
 
     - name: Run test
       run: .ci/test.sh


### PR DESCRIPTION
We are in the transition to use ephemeral workers, but until then there is a requirement to decommission the existing MacOS workers. For such this proposal uses GitHub actions for MacOS until we can use the ephemeral workers.