### PR TITLE
atomic64: add loong64 build support.

### DIFF
--- a/atomic/atomic64.go
+++ b/atomic/atomic64.go
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x
+//go:build amd64 || arm64 || loong64 || ppc64 || ppc64le || mips64 || mips64le || s390x
+// +build amd64 arm64 loong64 ppc64 ppc64le mips64 mips64le s390x
 
 package atomic
 


### PR DESCRIPTION
Go 1.19 introduced support for linux/loong64.

go version go1.19 linux/loong64
go test ./...
```
ok  	github.com/elastic/go-concert	0.003s
ok  	github.com/elastic/go-concert/atomic	0.009s
ok  	github.com/elastic/go-concert/ctxtool	0.027s
ok  	github.com/elastic/go-concert/ctxtool/osctx	0.008s
ok  	github.com/elastic/go-concert/timed	0.796s
ok  	github.com/elastic/go-concert/unison	0.235s
```
