### PR TITLE
Use core-windows-2022 instead of unmaintained ci-windows-2022 image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,7 @@ steps:
           SETUP_GOLANG_VERSION: "{{matrix.go_version}}"
         agents:
           provider: "gcp"
-          image: "family/ci-windows-2022"
+          image: "family/core-windows-2022"
         artifact_paths:
           - "build/junit-*-win.xml"
 


### PR DESCRIPTION
The image family `ci-windows-2022` has been unmaintained for a while and has been replaced by `core-windows-2022`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)